### PR TITLE
Update action to use Node.js 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   build:
     name: Build and Push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
         with:
           ref: v1
 
@@ -19,15 +19,15 @@ jobs:
           git fetch
           git merge origin/master
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
 
       - name: Get yarn cache directory
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   basic-test:
     name: Basic Testing
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Create dummy file
         run: |
@@ -24,7 +24,7 @@ jobs:
 
   additional-path-directory-test:
     name: Additional Path(Directory) Testing
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - uses: yumis-coconudge/clean-workspace-action@v1
 
@@ -64,7 +64,7 @@ jobs:
 
   additional-path-multiple-files-test:
     name: Additional Path(Multiple Files) Testing
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Create dummy files
         run: |

--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: "Additional path to clean"
     required: false
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Greetings, @toy0605 . I'm using your action really well in my team.
I want to prepare the upcoming GitHub Enterprise upgrade which is going to use Node.js 20.
I will be glad if I can cleanup warnings about the deprecation of Node.js 16 with the changes.

Would you consider another release with this?

### Changes

* Update runner images to the latest if possible.
   * `ubuntu-22.04`
   * `macos-latest`
* Change several GitHub Action to the latest (which supports Node.js v20)

### References

* https://github.com/actions/runner-images/
* https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
   * https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-using-nodejs-v20
